### PR TITLE
ardana: Fix ardana init playbook

### DIFF
--- a/ardana/ansible/init.yml
+++ b/ardana/ansible/init.yml
@@ -1,12 +1,19 @@
 ---
-- name: Download ardana-init
-  get_url:
-    url: https://raw.githubusercontent.com/toabctl/automation/ardana-ci/ardana/ansible/ardana-init.bash
-    dest: /var/lib/ardana/ardana-init.bash
-    mode: 0664
-    owner: ardana
+- name: Initialize the Deployer
+  hosts: hosts
+  gather_facts: False
 
-- name: Call ardana-init
-  shell: /var/lib/ardana/ardana-init.bash
-  become: true
-  become_user: ardana
+  tasks:
+  - name: Download ardana-init
+    get_url:
+      url: https://raw.githubusercontent.com/toabctl/automation/ardana-ci/ardana/ardana-init.bash
+      dest: /var/lib/ardana/ardana-init.bash
+      mode: 0775
+      owner: ardana
+    become: true
+    become_user: ardana
+
+  - name: Call ardana-init
+    shell: ARDANA_INIT_AUTO=1 /var/lib/ardana/ardana-init.bash
+    become: true
+    become_user: ardana


### PR DESCRIPTION
- Add the required boilerplate to the playbook
- Fix ardana-init url
- Set execute permission on the ardana-init script
- Call it with ARDANA_INIT_AUTO=1 to avoid it prompting for ssh key
  passphrase